### PR TITLE
Try Python 3 imports first

### DIFF
--- a/cfnresponse.py
+++ b/cfnresponse.py
@@ -1,10 +1,10 @@
 import json
 
 try:
-    from urllib2 import HTTPError, build_opener, HTTPHandler, Request
-except ImportError:
     from urllib.error import HTTPError
     from urllib.request import build_opener, HTTPHandler, Request
+except ImportError:
+    from urllib2 import HTTPError, build_opener, HTTPHandler, Request
 
 
 SUCCESS = "SUCCESS"

--- a/tests.py
+++ b/tests.py
@@ -3,14 +3,14 @@ import unittest
 from functools import partial
 
 try:
-    from urllib2 import HTTPError
-except ImportError:
     from urllib.error import HTTPError
+except ImportError:
+    from urllib2 import HTTPError
 
 try:
-    from mock import patch, Mock, call
+    from unittest.mock import patch, Mock
 except ImportError:
-    from unittest.mock import patch, Mock, call
+    from mock import patch, Mock
 
 from cfnresponse import send
 

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ envlist = py{27,33,34,35}
 [testenv]
 commands =
     python setup.py test
-    flake8 cfnresponse.py
+    flake8 cfnresponse.py tests.py
 
 deps =
     mock>=1.0.0; python_version<='3.3'


### PR DESCRIPTION
For the best forwards compatibility one should try the Python 3 imports first. You never know, the Python 2 environment may include backports of the future packages.

Also removed unused import of `unittest.mock.call`.